### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/opensource/clearpool/util/H2Util.java
+++ b/src/main/java/org/opensource/clearpool/util/H2Util.java
@@ -19,6 +19,9 @@ public class H2Util {
 
   public static final int XA_DATA_SOURCE = 13;
 
+  private H2Util() {
+  }
+
   public static Object createJdbcDataSourceFactory() {
     return new JdbcDataSourceFactory();
   }

--- a/src/main/java/org/opensource/clearpool/util/JdbcUtil.java
+++ b/src/main/java/org/opensource/clearpool/util/JdbcUtil.java
@@ -19,6 +19,9 @@ public final class JdbcUtil {
   private static final String DB2_DRIVER = "COM.ibm.db2.jdbc.app.DB2Driver";
   private static final String H2_DRIVER = "org.h2.Driver";
 
+  private JdbcUtil() {
+  }
+
   public static String getDriverClassName(String rawUrl) throws SQLException {
     if (rawUrl.startsWith("jdbc:derby:")) {
       return "org.apache.derby.jdbc.EmbeddedDriver";

--- a/src/main/java/org/opensource/clearpool/util/MysqlUtil.java
+++ b/src/main/java/org/opensource/clearpool/util/MysqlUtil.java
@@ -12,6 +12,9 @@ import com.mysql.jdbc.jdbc2.optional.MysqlXAConnection;
 import com.mysql.jdbc.jdbc2.optional.SuspendableXAConnection;
 
 public class MysqlUtil {
+  private MysqlUtil() {
+  }
+
   public static XAConnection mysqlXAConnection(Connection con) throws SQLException {
     ConnectionImpl mysqlConn = (ConnectionImpl) con;
     if (mysqlConn.getPinGlobalTxToPhysicalConnection()) {

--- a/src/main/java/org/opensource/clearpool/util/OracleUtil.java
+++ b/src/main/java/org/opensource/clearpool/util/OracleUtil.java
@@ -10,6 +10,9 @@ import oracle.jdbc.xa.client.OracleXAConnection;
 import org.opensource.clearpool.exception.TransactionException;
 
 public class OracleUtil {
+  private OracleUtil() {
+  }
+
   public static XAConnection oracleXAConnection(Connection oracleConnection) {
     try {
       return new OracleXAConnection(oracleConnection);

--- a/src/main/java/org/opensource/clearpool/util/PGUtil.java
+++ b/src/main/java/org/opensource/clearpool/util/PGUtil.java
@@ -9,6 +9,9 @@ import org.postgresql.core.BaseConnection;
 import org.postgresql.xa.PGXAConnection;
 
 public class PGUtil {
+  private PGUtil() {
+  }
+
   public static XAConnection createXAConnection(Connection physicalConn) throws SQLException {
     return new PGXAConnection((BaseConnection) physicalConn);
   }

--- a/src/main/java/org/opensource/clearpool/util/PoolLatchUtil.java
+++ b/src/main/java/org/opensource/clearpool/util/PoolLatchUtil.java
@@ -16,6 +16,9 @@ public class PoolLatchUtil {
   // 2 hooks: IdleCheckHook and HtmlAdaptorHook.
   private static CountDownLatch startLatch = new CountDownLatch(2);
 
+  private PoolLatchUtil() {
+  }
+
   /**
    * Count down startLatch.
    */

--- a/src/main/java/org/opensource/clearpool/util/ThreadSleepUtil.java
+++ b/src/main/java/org/opensource/clearpool/util/ThreadSleepUtil.java
@@ -10,6 +10,9 @@ package org.opensource.clearpool.util;
 public class ThreadSleepUtil {
   private final static long MINUTE = 60 * 1000L;
 
+  private ThreadSleepUtil() {
+  }
+
   /**
    * release CPU:if the thread don't sleep,the CPU will be used by this thread all the time.
    */

--- a/src/test/java/org/opensource/clearpool/util/GCUtil.java
+++ b/src/test/java/org/opensource/clearpool/util/GCUtil.java
@@ -10,6 +10,9 @@ import javax.management.ObjectName;
  */
 public class GCUtil {
 
+  private GCUtil() {
+  }
+
   public static long getYoungGC() {
     try {
       MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();

--- a/src/test/java/org/opensource/clearpool/util/MemoryUtil.java
+++ b/src/test/java/org/opensource/clearpool/util/MemoryUtil.java
@@ -2,6 +2,9 @@ package org.opensource.clearpool.util;
 
 public class MemoryUtil {
 
+  private MemoryUtil() {
+  }
+
   /**
    * Print memory
    */

--- a/src/test/java/org/opensource/clearpool/util/ThreadProcessUtil.java
+++ b/src/test/java/org/opensource/clearpool/util/ThreadProcessUtil.java
@@ -11,8 +11,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.sql.DataSource;
 
 public class ThreadProcessUtil {
+  private ThreadProcessUtil() {
+  }
+
   public static void process(final DataSource dataSource, String name, final int loop,
-      int threadCount, final AtomicLong physicalConnStat) throws Exception {
+                             int threadCount, final AtomicLong physicalConnStat) throws Exception {
     realProcess(dataSource, name, loop, threadCount, physicalConnStat, null);
   }
 

--- a/src/test/java/org/opensource/clearpool/util/XMLUtil.java
+++ b/src/test/java/org/opensource/clearpool/util/XMLUtil.java
@@ -16,6 +16,9 @@ public class XMLUtil {
       "http://java.sun.com/xml/jaxp/properties/schemaLanguage";
   private static final String XSD_SCHEMA_LANGUAGE = "http://www.w3.org/2001/XMLSchema";
 
+  private XMLUtil() {
+  }
+
   public static Document createDocument(String path) throws Exception {
     Reader reader = getResourceAsReader(path);
     InputSource inputSource = new InputSource(reader);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
